### PR TITLE
Fix typo of “keywords” in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ authors = [
 
 ]
 # Optional, a list of keywords for this template
-kewyords = [
+keywords = [
 
 ]
 # Optional, those files will NOT be copied over when generating the template


### PR DESCRIPTION
[src/definition.rs line 59](https://github.com/Keats/kickstart/blob/ee9e6d194197f59408dd1a3588d3583f175c554e/src/definition.rs#L59) shows that the correct spelling is “keywords”.