### PR TITLE
Add support for subdirectories in repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The main drawback compared to cookiecutter is the lack of hook scripts support, 
 $ kickstart examples/super-basic
 $ kickstart examples/complex -o Hello
 # Anywhere
+$ kickstart https://github.com/Keats/kickstart -s examples/super-basic
 $ kickstart https://github.com/Keats/kickstart-sample -o sample
 # Additionally, kickstart supports git URL shorthands (see [#19](https://github.com/Keats/kickstart/issues/19))
 # Here, gl maps to `https://gitlab.com/`

--- a/src/bin/kickstart.rs
+++ b/src/bin/kickstart.rs
@@ -32,6 +32,13 @@ pub fn build_cli() -> App<'static, 'static> {
                 .help("Where to output the project: defaults to the current directory")
         )
         .arg(
+            Arg::with_name("sub-dir")
+                .short("s")
+                .long("sub-dir")
+                .takes_value(true)
+                .help("A subdirectory of the chosen template to use, to allow nested templates.")
+        )
+        .arg(
             Arg::with_name("no-input")
                 .long("no-input")
                 .help("Do not prompt for parameters and only use the defaults from template.toml")
@@ -90,8 +97,9 @@ fn main() {
                 .map(|p| Path::new(p).to_path_buf())
                 .unwrap_or_else(|| env::current_dir().unwrap());
             let no_input = matches.is_present("no-input");
+            let sub_dir = matches.value_of("sub-dir");
 
-            let template = match Template::from_input(template_path) {
+            let template = match Template::from_input(template_path, sub_dir) {
                 Ok(t) => t,
                 Err(e) => bail(e),
             };

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -176,7 +176,7 @@ mod tests {
     #[test]
     fn can_generate_from_local_path() {
         let dir = tempdir().unwrap();
-        let tpl = Template::from_input("examples/complex").unwrap();
+        let tpl = Template::from_input("examples/complex", None).unwrap();
         let res = tpl.generate(&dir.path().to_path_buf(), true);
         assert!(res.is_ok());
         assert!(!dir.path().join("some-project").join("template.toml").exists());
@@ -186,7 +186,7 @@ mod tests {
     #[test]
     fn can_generate_from_remote_repo() {
         let dir = tempdir().unwrap();
-        let tpl = Template::from_input("https://github.com/Keats/rust-cli-template").unwrap();
+        let tpl = Template::from_input("https://github.com/Keats/rust-cli-template", None).unwrap();
         let res = tpl.generate(&dir.path().to_path_buf(), true);
         assert!(res.is_ok());
         assert!(!dir.path().join("My-CLI").join("template.toml").exists());

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -184,6 +184,16 @@ mod tests {
     }
 
     #[test]
+    fn can_generate_from_local_path_with_subdir() {
+        let dir = tempdir().unwrap();
+        let tpl = Template::from_input("./", Some("examples/complex")).unwrap();
+        let res = tpl.generate(&dir.path().to_path_buf(), true);
+        assert!(res.is_ok());
+        assert!(!dir.path().join("some-project").join("template.toml").exists());
+        assert!(dir.path().join("some-project").join("logo.png").exists());
+    }
+
+    #[test]
     fn can_generate_from_remote_repo() {
         let dir = tempdir().unwrap();
         let tpl = Template::from_input("https://github.com/Keats/rust-cli-template", None).unwrap();
@@ -191,5 +201,15 @@ mod tests {
         assert!(res.is_ok());
         assert!(!dir.path().join("My-CLI").join("template.toml").exists());
         assert!(dir.path().join("My-CLI").join(".travis.yml").exists());
+    }
+
+    #[test]
+    fn can_generate_from_remote_repo_with_subdir() {
+        let dir = tempdir().unwrap();
+        let tpl = Template::from_input("https://github.com/Keats/kickstart", Some("examples/complex")).unwrap();
+        let res = tpl.generate(&dir.path().to_path_buf(), true);
+        assert!(res.is_ok());
+        assert!(!dir.path().join("some-project").join("template.toml").exists());
+        assert!(dir.path().join("some-project").join("logo.png").exists());
     }
 }


### PR DESCRIPTION
This PR will add support for a `-s` flag, which allows usage of a subdirectory inside a template. This would allow a couple of cool things: 

- Distributing templates inside core repositories (my use case).
- Having a personal repo full of your own templates, for your preferences.
- Having a community repository full of standard templates. 

I thought about filing an issue, but whilst I was looking I figured I'd just file a PR for it. Do you have any thoughts? I picked the flag/option on a whim, so happy to change!