### PR TITLE
Add lowercase and uppercase cc filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ Case conversion filters are provided (_via [heck](https://github.com/withoutboat
 - `shouty_snake_case`: SHOUTY_SNAKE_CASE
 - `title_case`: Title Case
 - `shouty_kebab_case`: SHOUTY-KEBAB-CASE
+- `lowercase`: lowercase
+- `uppercase`: UPPERCASE
 
 You can use these like any other filter, e.g. `{{variable_name | camel_case}}`.
 

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -11,6 +11,8 @@ pub fn register_all_filters(tera: &mut Tera) {
     tera.register_filter("shouty_snake_case", shouty_snake_case);
     tera.register_filter("title_case", title_case);
     tera.register_filter("shouty_kebab_case", shouty_kebab_case);
+    tera.register_filter("lowercase", lowercase);
+    tera.register_filter("uppercase", uppercase);
 }
 
 pub fn upper_camel_case(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
@@ -46,4 +48,14 @@ pub fn title_case(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
 pub fn shouty_kebab_case(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
     let s = try_get_value!("shouty_kebab_case", "value", String, value);
     Ok(to_value(s.to_shouty_kebab_case()).unwrap())
+}
+
+pub fn lowercase(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
+    let s = try_get_value!("lowercase", "value", String, value);
+    Ok(to_value(s.to_lowercase()).unwrap())
+}
+
+pub fn uppercase(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
+    let s = try_get_value!("uppercase", "value", String, value);
+    Ok(to_value(s.to_uppercase()).unwrap())
 }


### PR DESCRIPTION
Didn't add them to heck because as it's part of stdlib it doesn't make sense to be in a library, but it's useful in this application.