### PR TITLE
configurable support for symlinks

### DIFF
--- a/src/definition.rs
+++ b/src/definition.rs
@@ -62,6 +62,9 @@ pub struct TemplateDefinition {
     /// The directory in which the template files are.
     /// Useful if a template has its own docs, README, CI and various files
     pub directory: Option<String>,
+    /// Follow symlinks
+    #[serde(default)]
+    pub symlinks: bool,
     /// Do not copy those directories/files
     #[serde(default)]
     pub ignore: Vec<String>,
@@ -200,6 +203,7 @@ mod tests {
             name = "Test template"
             description = "A description"
             kickstart_version = 1
+            symlinks = false
 
             [[variables]]
             name = "project_name"

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -95,7 +95,7 @@ impl Template {
         };
 
         // And now generate the files in the output dir given
-        let walker = WalkDir::new(&start_path)
+        let walker = WalkDir::new(&start_path).follow_links(definition.symlinks)
             .into_iter()
             .filter_entry(|e| {
                 // Ignore .git/ folder


### PR DESCRIPTION
Was recently shopping around for a good scaffolding tool for projects and found kickstart, the only feature missing for me was the ability to follow symlinks so I can share common files between templates. This simple PR adds the ability to follow symlinks as a template config parameter but does not change the default behavior. 