### PR TITLE
feat: Add Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,13 @@ COPY examples ./examples
 # Build the application with CLI features
 RUN cargo build --release --features cli
 
-# Runtime stage - Debian 12 distroless
-FROM gcr.io/distroless/cc-debian12:nonroot
+# Runtime stage - Debian 12 slim
+FROM debian:12-slim
+
+# Install ca-certificates
+RUN apt-get update && \
+    apt-get install -y ca-certificates git && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy the binary from builder
 COPY --from=builder /app/target/release/kickstart /usr/local/bin/kickstart


### PR DESCRIPTION
This Dockerfile allow to create a docker image for running kickstart without download the binary and working with the same binary in Windows, Linux and OSX

An example for running using docker:
docker run -it  ghcr.io/sevir/kickstart:latest --help

I've pushed the image into the Github Container Registry, but works with any docker image