### PR TITLE
fix: use current directory as default for output_dir arg

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ pub struct Cli {
     pub template: Option<String>,
 
     /// Where to output the project: defaults to the current directory
-    #[clap(short = 'o', long)]
+    #[clap(short = 'o', long, default_value_os_t = PathBuf::from("."))]
     pub output_dir: PathBuf,
 
     /// The directory of the given folder/repository to use, which needs to be a template.


### PR DESCRIPTION
Closes #76 

### Description

Sets the default value for `-o`/`--output-dir` argument to current directory.

### Example

#### Template validation:

<img width="760" height="101" alt="image" src="https://github.com/user-attachments/assets/eece78e1-2a4b-4eac-8ba3-8ea48942cfcb" />

Notice the absence of `-o`/`--output-dir` arg

#### Scaffolding at custom directory:

<img width="978" height="239" alt="image" src="https://github.com/user-attachments/assets/960d1d55-7060-42c2-8a7d-41a39527302a" />

<img width="573" height="129" alt="image" src="https://github.com/user-attachments/assets/fa7c360f-c97b-4b45-821e-ec4ef5089021" />

#### Scaffolding at current directory (default)

<img width="529" height="199" alt="image" src="https://github.com/user-attachments/assets/57fa025b-aa39-48eb-b0ac-f4753e9d4273" />

<img width="615" height="157" alt="image" src="https://github.com/user-attachments/assets/eb556c35-85d9-45be-9474-b2612b14583a" />
